### PR TITLE
Add simple Steam manager skeleton

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,26 @@
 # SteamTrush
 
-Краткое описание. Например:
+SteamTrush is a simple experimental tool for managing multiple Steam accounts.
+It demonstrates how to login with SteamKit2, fetch XP via the Steam Web API and
+launch Counter-Strike 2 from different accounts. The application supports both
+English and Russian languages.
 
-Этот проект создан для тестирования Codex (ChatGPT Code Interpreter).
+## Building
+1. Install the .NET 7 SDK.
+2. Run `dotnet restore` and `dotnet run` inside the `SteamManager` directory.
+
+## Configuration
+Create an `accounts.json` file with the following structure:
+
+```json
+[
+  {
+    "Username": "user1",
+    "Password": "pass1",
+    "SteamId": "7656119...",
+    "ApiKey": "XXXXXXXXXXXX"
+  }
+]
+```
+
+Set the environment variable `STEAM_MANAGER_LANG` to `ru` for Russian UI.

--- a/SteamManager/AccountConfig.cs
+++ b/SteamManager/AccountConfig.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace SteamManager
+{
+    public class Account
+    {
+        public string Username { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+        public string SteamId { get; set; } = string.Empty;
+        public string ApiKey { get; set; } = string.Empty;
+    }
+
+    public static class AccountConfig
+    {
+        public static List<Account> Load(string file)
+        {
+            if (!File.Exists(file)) return new List<Account>();
+            var json = File.ReadAllText(file);
+            return JsonSerializer.Deserialize<List<Account>>(json) ?? new List<Account>();
+        }
+    }
+}

--- a/SteamManager/GameLauncher.cs
+++ b/SteamManager/GameLauncher.cs
@@ -1,0 +1,13 @@
+using System.Diagnostics;
+
+namespace SteamManager
+{
+    public static class GameLauncher
+    {
+        public static void LaunchCS2(Account account)
+        {
+            var args = $"-login {account.Username} {account.Password} -applaunch 730";
+            Process.Start("steam", args);
+        }
+    }
+}

--- a/SteamManager/Program.cs
+++ b/SteamManager/Program.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace SteamManager
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var culture = LoadCulture();
+            var accounts = AccountConfig.Load("accounts.json");
+            Console.WriteLine(Resources.Strings.Welcome);
+            foreach (var account in accounts)
+            {
+                Console.WriteLine($"{account.Username} - {account.SteamId}");
+                SteamApi.FetchLevel(account).Wait();
+                GameLauncher.LaunchCS2(account);
+            }
+        }
+
+        static CultureInfo LoadCulture()
+        {
+            var lang = Environment.GetEnvironmentVariable("STEAM_MANAGER_LANG");
+            if (lang == "ru")
+            {
+                Resources.Strings.Culture = new CultureInfo("ru-RU");
+            }
+            else
+            {
+                Resources.Strings.Culture = new CultureInfo("en-US");
+            }
+            return Resources.Strings.Culture;
+        }
+    }
+}

--- a/SteamManager/Resources/Strings.Designer.cs
+++ b/SteamManager/Resources/Strings.Designer.cs
@@ -1,0 +1,32 @@
+namespace SteamManager.Resources {
+    using System;
+    using System.Reflection;
+    using System.Resources;
+    using System.Globalization;
+
+    internal static class Strings {
+        private static ResourceManager resourceMan;
+        private static CultureInfo resourceCulture;
+
+        internal static ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
+                    var temp = new ResourceManager("SteamManager.Resources.Strings", typeof(Strings).GetTypeInfo().Assembly);
+                    resourceMan = temp;
+                }
+                return resourceMan;
+            }
+        }
+
+        internal static CultureInfo Culture {
+            get { return resourceCulture; }
+            set { resourceCulture = value; }
+        }
+
+        internal static string Welcome {
+            get {
+                return ResourceManager.GetString("Welcome", resourceCulture);
+            }
+        }
+    }
+}

--- a/SteamManager/Resources/Strings.resx
+++ b/SteamManager/Resources/Strings.resx
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Welcome" xml:space="preserve">
+    <value>Welcome to Steam Manager</value>
+  </data>
+</root>

--- a/SteamManager/Resources/Strings.ru.resx
+++ b/SteamManager/Resources/Strings.ru.resx
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Welcome" xml:space="preserve">
+    <value>Добро пожаловать в Steam Manager</value>
+  </data>
+</root>

--- a/SteamManager/SteamApi.cs
+++ b/SteamManager/SteamApi.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace SteamManager
+{
+    public static class SteamApi
+    {
+        static HttpClient client = new HttpClient();
+
+        public static async Task FetchLevel(Account account)
+        {
+            if (string.IsNullOrEmpty(account.ApiKey) || string.IsNullOrEmpty(account.SteamId))
+            {
+                Console.WriteLine($"{account.Username}: API key or Steam ID missing");
+                return;
+            }
+            try
+            {
+                var url = $"https://api.steampowered.com/IPlayerService/GetBadges/v1/?key={account.ApiKey}&steamid={account.SteamId}";
+                var json = await client.GetStringAsync(url);
+                using var doc = JsonDocument.Parse(json);
+                if (doc.RootElement.TryGetProperty("response", out var resp) && resp.TryGetProperty("player_xp", out var xp))
+                {
+                    Console.WriteLine($"{account.Username}: XP {xp.GetInt32()}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"API error: {ex.Message}");
+            }
+        }
+    }
+}

--- a/SteamManager/SteamManager.csproj
+++ b/SteamManager/SteamManager.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <RootNamespace>SteamManager</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="SteamKit2" Version="2.4.0" />
+  </ItemGroup>
+</Project>

--- a/SteamManager/TradeManager.cs
+++ b/SteamManager/TradeManager.cs
@@ -1,0 +1,32 @@
+using System;
+using SteamKit2;
+
+namespace SteamManager
+{
+    public class TradeManager
+    {
+        private readonly SteamClient _client = new SteamClient();
+        private CallbackManager _manager;
+        private SteamUser _user;
+        private SteamUser.LogOnDetails _logOnDetails;
+
+        public TradeManager(Account account)
+        {
+            _manager = new CallbackManager(_client);
+            _user = _client.GetHandler<SteamUser>();
+            _logOnDetails = new SteamUser.LogOnDetails
+            {
+                Username = account.Username,
+                Password = account.Password
+            };
+        }
+
+        public void LoginAndSendOffer()
+        {
+            _client.Connect();
+            _manager.RunCallbacks();
+            _user.LogOn(_logOnDetails);
+            // TODO: handle callbacks and send trade offer
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement a minimal console app under `SteamManager`
- support English and Russian via resources
- fetch XP with Steam Web API and launch CS2
- stub out trade functionality with SteamKit2
- document build and configuration steps

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c36bbc40c83329eb01a82b25b717b